### PR TITLE
AI 챗봇 앱 [STEP 5] 뉴준성

### DIFF
--- a/ChatBot/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot/ChatBot.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		0D66D0DF2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */; };
 		0D66D0E12B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */; };
 		0D66D0E52B60C42300F518CE /* PromptSetting+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */; };
+		0D66D0EB2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */; };
+		0D66D0EE2B60CAB500F518CE /* GPTPromptSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */; };
+		0D66D0F12B60D4F100F518CE /* GPTPromptSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */; };
 		0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */; };
 		0D843ADB2B4B98C900F4EAD2 /* GPTHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */; };
 		0D843ADD2B4B992500F4EAD2 /* DataDecoderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */; };
@@ -106,6 +109,9 @@
 		0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataClass.swift"; sourceTree = "<group>"; };
 		0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatRoom+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPTPromptSettingVMProtocol.swift; path = ../../../../../../../../../.Trash/GPTPromptSetting/ViewModel/Protocols/GPTPromptSettingVMProtocol.swift; sourceTree = "<group>"; };
+		0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewModel.swift; sourceTree = "<group>"; };
+		0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewController.swift; sourceTree = "<group>"; };
 		0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+HTTPPublishable.swift"; sourceTree = "<group>"; };
 		0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTHTTPService.swift; sourceTree = "<group>"; };
 		0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDecoderable.swift; sourceTree = "<group>"; };
@@ -374,6 +380,48 @@
 			path = Implements;
 			sourceTree = "<group>";
 		};
+		0D66D0E62B60C92E00F518CE /* GPTPromptSetting */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0EF2B60D49E00F518CE /* ViewController */,
+				0D66D0E72B60C96800F518CE /* ViewModel */,
+			);
+			path = GPTPromptSetting;
+			sourceTree = "<group>";
+		};
+		0D66D0E72B60C96800F518CE /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0EC2B60CA9A00F518CE /* Implements */,
+				0D66D0E82B60C96D00F518CE /* Protocols */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		0D66D0E82B60C96D00F518CE /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		0D66D0EC2B60CA9A00F518CE /* Implements */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */,
+			);
+			path = Implements;
+			sourceTree = "<group>";
+		};
+		0D66D0EF2B60D49E00F518CE /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		0D843AD92B4B98B200F4EAD2 /* HTTPService */ = {
 			isa = PBXGroup;
 			children = (
@@ -509,6 +557,7 @@
 		0D843B202B4FAE8B00F4EAD2 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				0D66D0E62B60C92E00F518CE /* GPTPromptSetting */,
 				0D3260402B5A4C42000C352E /* GPTChatRooms */,
 				0D843B212B4FAE9700F4EAD2 /* GPTChatting */,
 			);
@@ -899,7 +948,9 @@
 				0D843AE92B4BA6D300F4EAD2 /* JSONEncoder+DataEncoderable.swift in Sources */,
 				0D3260162B5A0A56000C352E /* ChatRoomRepositable.swift in Sources */,
 				0D3260432B5A4C83000C352E /* GPTChatRoomsVMProtocol.swift in Sources */,
+				0D66D0EE2B60CAB500F518CE /* GPTPromptSettingViewModel.swift in Sources */,
 				0D66D0E12B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift in Sources */,
+				0D66D0F12B60D4F100F518CE /* GPTPromptSettingViewController.swift in Sources */,
 				0DF997B52B479C0A0055C836 /* HTTPError.swift in Sources */,
 				0D3260592B5E21A9000C352E /* UIAlertController+Extension.swift in Sources */,
 				0D3260062B57724B000C352E /* AppEnviroment.swift in Sources */,
@@ -934,6 +985,7 @@
 				0D66D0D72B60AE2000F518CE /* CoreDataPromptSettingRepository.swift in Sources */,
 				B4B3E2BD2B42D1BB00818B3C /* AppDelegate.swift in Sources */,
 				0D32601A2B5A0E6C000C352E /* CoreDataRepository.swift in Sources */,
+				0D66D0EB2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */,
 				0DF9976D2B43B15F0055C836 /* GPTMessagable.swift in Sources */,
 				0DF997812B450E8E0055C836 /* Date+Extention.swift in Sources */,
 				0D3260532B5D45C0000C352E /* CoreDataChattingRepository.swift in Sources */,

--- a/ChatBot/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot/ChatBot.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		0D66D0EB2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */; };
 		0D66D0EE2B60CAB500F518CE /* GPTPromptSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */; };
 		0D66D0F12B60D4F100F518CE /* GPTPromptSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */; };
+		0D66D0F52B62144000F518CE /* UITextView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0F42B62144000F518CE /* UITextView+Extension.swift */; };
 		0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */; };
 		0D843ADB2B4B98C900F4EAD2 /* GPTHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */; };
 		0D843ADD2B4B992500F4EAD2 /* DataDecoderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */; };
@@ -112,6 +113,7 @@
 		0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPTPromptSettingVMProtocol.swift; path = ../../../../../../../../../.Trash/GPTPromptSetting/ViewModel/Protocols/GPTPromptSettingVMProtocol.swift; sourceTree = "<group>"; };
 		0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewModel.swift; sourceTree = "<group>"; };
 		0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewController.swift; sourceTree = "<group>"; };
+		0D66D0F42B62144000F518CE /* UITextView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Extension.swift"; sourceTree = "<group>"; };
 		0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+HTTPPublishable.swift"; sourceTree = "<group>"; };
 		0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTHTTPService.swift; sourceTree = "<group>"; };
 		0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDecoderable.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 			isa = PBXGroup;
 			children = (
 				0D3260582B5E21A9000C352E /* UIAlertController+Extension.swift */,
+				0D66D0F42B62144000F518CE /* UITextView+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -939,6 +942,7 @@
 			files = (
 				0D3260142B5A08DD000C352E /* ChatBotCoreData.xcdatamodeld in Sources */,
 				0DF997742B43BCC50055C836 /* AssistantMessage.swift in Sources */,
+				0D66D0F52B62144000F518CE /* UITextView+Extension.swift in Sources */,
 				0D843B1A2B4E88AC00F4EAD2 /* GPTRequest.swift in Sources */,
 				0DF9977E2B45022A0055C836 /* UserMessage.swift in Sources */,
 				0D32604A2B5A4CFD000C352E /* GPTChatRoomsViewController.swift in Sources */,

--- a/ChatBot/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot/ChatBot.xcodeproj/project.pbxproj
@@ -185,11 +185,11 @@
 		0D32600D2B5A085D000C352E /* Repository */ = {
 			isa = PBXGroup;
 			children = (
-				0D66D0D12B60AD2000F518CE /* PromptSettingRepository */,
-				0D32604D2B5D44BD000C352E /* ChattingRepository */,
-				0D3260202B5A18D0000C352E /* ChatRoomRepository */,
-				0D3260182B5A0E4B000C352E /* CoreDataRepository */,
 				0D32601B2B5A1523000C352E /* Repository.swift */,
+				0D3260202B5A18D0000C352E /* ChatRoomRepository */,
+				0D32604D2B5D44BD000C352E /* ChattingRepository */,
+				0D3260182B5A0E4B000C352E /* CoreDataRepository */,
+				0D66D0D12B60AD2000F518CE /* PromptSettingRepository */,
 			);
 			path = Repository;
 			sourceTree = "<group>";

--- a/ChatBot/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot/ChatBot.xcodeproj/project.pbxproj
@@ -31,10 +31,12 @@
 		0D66D0DF2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */; };
 		0D66D0E12B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */; };
 		0D66D0E52B60C42300F518CE /* PromptSetting+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */; };
-		0D66D0EB2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */; };
 		0D66D0EE2B60CAB500F518CE /* GPTPromptSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */; };
 		0D66D0F12B60D4F100F518CE /* GPTPromptSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */; };
 		0D66D0F52B62144000F518CE /* UITextView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0F42B62144000F518CE /* UITextView+Extension.swift */; };
+		0D66D0FE2B63528500F518CE /* StubHTTPPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0FD2B63528500F518CE /* StubHTTPPublisher.swift */; };
+		0D66D1002B6354EF00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0FF2B6354EF00F518CE /* GPTPromptSettingVMProtocol.swift */; };
+		0D66D1022B6363A500F518CE /* GPTChattingVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D1012B6363A500F518CE /* GPTChattingVMTests.swift */; };
 		0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */; };
 		0D843ADB2B4B98C900F4EAD2 /* GPTHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */; };
 		0D843ADD2B4B992500F4EAD2 /* DataDecoderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */; };
@@ -110,10 +112,12 @@
 		0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataClass.swift"; sourceTree = "<group>"; };
 		0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatRoom+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GPTPromptSettingVMProtocol.swift; path = ../../../../../../../../../.Trash/GPTPromptSetting/ViewModel/Protocols/GPTPromptSettingVMProtocol.swift; sourceTree = "<group>"; };
 		0D66D0ED2B60CAB500F518CE /* GPTPromptSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewModel.swift; sourceTree = "<group>"; };
 		0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingViewController.swift; sourceTree = "<group>"; };
 		0D66D0F42B62144000F518CE /* UITextView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Extension.swift"; sourceTree = "<group>"; };
+		0D66D0FD2B63528500F518CE /* StubHTTPPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubHTTPPublisher.swift; sourceTree = "<group>"; };
+		0D66D0FF2B6354EF00F518CE /* GPTPromptSettingVMProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTPromptSettingVMProtocol.swift; sourceTree = "<group>"; };
+		0D66D1012B6363A500F518CE /* GPTChattingVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTChattingVMTests.swift; sourceTree = "<group>"; };
 		0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+HTTPPublishable.swift"; sourceTree = "<group>"; };
 		0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTHTTPService.swift; sourceTree = "<group>"; };
 		0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDecoderable.swift; sourceTree = "<group>"; };
@@ -241,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				0D843AF62B4CE94700F4EAD2 /* ChatBotNetworkTests.swift */,
+				0D66D1012B6363A500F518CE /* GPTChattingVMTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -404,7 +409,7 @@
 		0D66D0E82B60C96D00F518CE /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				0D66D0EA2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift */,
+				0D66D0FF2B6354EF00F518CE /* GPTPromptSettingVMProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -423,6 +428,14 @@
 				0D66D0F02B60D4F100F518CE /* GPTPromptSettingViewController.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		0D66D0FC2B63526D00F518CE /* Stubs */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0FD2B63528500F518CE /* StubHTTPPublisher.swift */,
+			);
+			path = Stubs;
 			sourceTree = "<group>";
 		};
 		0D843AD92B4B98B200F4EAD2 /* HTTPService */ = {
@@ -487,6 +500,7 @@
 		0D843AF52B4CE94700F4EAD2 /* ChatBotTests */ = {
 			isa = PBXGroup;
 			children = (
+				0D66D0FC2B63526D00F518CE /* Stubs */,
 				0D32603B2B5A354F000C352E /* Tests */,
 				0D843B152B4D169F00F4EAD2 /* Mocks */,
 				0D843B0A2B4D03D200F4EAD2 /* Resources */,
@@ -929,8 +943,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0D66D1022B6363A500F518CE /* GPTChattingVMTests.swift in Sources */,
 				0D843B092B4D02DB00F4EAD2 /* MockHTTPPublisher.swift in Sources */,
 				0D843AF72B4CE94700F4EAD2 /* ChatBotNetworkTests.swift in Sources */,
+				0D66D0FE2B63528500F518CE /* StubHTTPPublisher.swift in Sources */,
 				0D843B112B4D0B8100F4EAD2 /* MockHTTPRequest.swift in Sources */,
 				0D843B142B4D142B00F4EAD2 /* JSONFetcher.swift in Sources */,
 			);
@@ -982,6 +998,7 @@
 				0D3260042B576BC9000C352E /* BezierPath+extension.swift in Sources */,
 				0D843B392B511F0A00F4EAD2 /* UIChatBubbleView.swift in Sources */,
 				0D843B342B50CFAD00F4EAD2 /* WaitingMessage.swift in Sources */,
+				0D66D1002B6354EF00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */,
 				0D32601C2B5A1523000C352E /* Repository.swift in Sources */,
 				0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */,
 				0D66D0D42B60AD5500F518CE /* PromptSettingRepositable.swift in Sources */,
@@ -989,7 +1006,6 @@
 				0D66D0D72B60AE2000F518CE /* CoreDataPromptSettingRepository.swift in Sources */,
 				B4B3E2BD2B42D1BB00818B3C /* AppDelegate.swift in Sources */,
 				0D32601A2B5A0E6C000C352E /* CoreDataRepository.swift in Sources */,
-				0D66D0EB2B60C98C00F518CE /* GPTPromptSettingVMProtocol.swift in Sources */,
 				0DF9976D2B43B15F0055C836 /* GPTMessagable.swift in Sources */,
 				0DF997812B450E8E0055C836 /* Date+Extention.swift in Sources */,
 				0D3260532B5D45C0000C352E /* CoreDataChattingRepository.swift in Sources */,

--- a/ChatBot/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot/ChatBot.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		0D32601F2B5A1651000C352E /* GPTChatRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D32601E2B5A1651000C352E /* GPTChatRoom.swift */; };
 		0D3260232B5A195C000C352E /* CoreDataChatRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260222B5A195C000C352E /* CoreDataChatRoomRepository.swift */; };
 		0D3260282B5A24CA000C352E /* ChatRoom+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260242B5A24CA000C352E /* ChatRoom+CoreDataClass.swift */; };
-		0D3260292B5A24CA000C352E /* ChatRoom+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260252B5A24CA000C352E /* ChatRoom+CoreDataProperties.swift */; };
 		0D32602A2B5A24CA000C352E /* Chatting+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260262B5A24CA000C352E /* Chatting+CoreDataClass.swift */; };
 		0D32602B2B5A24CA000C352E /* Chatting+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260272B5A24CA000C352E /* Chatting+CoreDataProperties.swift */; };
 		0D32602D2B5A2B92000C352E /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D32602C2B5A2B92000C352E /* RepositoryError.swift */; };
@@ -27,6 +26,11 @@
 		0D3260512B5D44FC000C352E /* ChattingRepositable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260502B5D44FC000C352E /* ChattingRepositable.swift */; };
 		0D3260532B5D45C0000C352E /* CoreDataChattingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260522B5D45C0000C352E /* CoreDataChattingRepository.swift */; };
 		0D3260592B5E21A9000C352E /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D3260582B5E21A9000C352E /* UIAlertController+Extension.swift */; };
+		0D66D0D42B60AD5500F518CE /* PromptSettingRepositable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0D32B60AD5500F518CE /* PromptSettingRepositable.swift */; };
+		0D66D0D72B60AE2000F518CE /* CoreDataPromptSettingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0D62B60AE2000F518CE /* CoreDataPromptSettingRepository.swift */; };
+		0D66D0DF2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */; };
+		0D66D0E12B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */; };
+		0D66D0E52B60C42300F518CE /* PromptSetting+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */; };
 		0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */; };
 		0D843ADB2B4B98C900F4EAD2 /* GPTHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */; };
 		0D843ADD2B4B992500F4EAD2 /* DataDecoderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */; };
@@ -88,7 +92,6 @@
 		0D32601E2B5A1651000C352E /* GPTChatRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTChatRoom.swift; sourceTree = "<group>"; };
 		0D3260222B5A195C000C352E /* CoreDataChatRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataChatRoomRepository.swift; sourceTree = "<group>"; };
 		0D3260242B5A24CA000C352E /* ChatRoom+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatRoom+CoreDataClass.swift"; sourceTree = "<group>"; };
-		0D3260252B5A24CA000C352E /* ChatRoom+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatRoom+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		0D3260262B5A24CA000C352E /* Chatting+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Chatting+CoreDataClass.swift"; sourceTree = "<group>"; };
 		0D3260272B5A24CA000C352E /* Chatting+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Chatting+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		0D32602C2B5A2B92000C352E /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
@@ -98,6 +101,11 @@
 		0D3260502B5D44FC000C352E /* ChattingRepositable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRepositable.swift; sourceTree = "<group>"; };
 		0D3260522B5D45C0000C352E /* CoreDataChattingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataChattingRepository.swift; sourceTree = "<group>"; };
 		0D3260582B5E21A9000C352E /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
+		0D66D0D32B60AD5500F518CE /* PromptSettingRepositable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSettingRepositable.swift; sourceTree = "<group>"; };
+		0D66D0D62B60AE2000F518CE /* CoreDataPromptSettingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPromptSettingRepository.swift; sourceTree = "<group>"; };
+		0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataClass.swift"; sourceTree = "<group>"; };
+		0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatRoom+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromptSetting+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		0D843AD72B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+HTTPPublishable.swift"; sourceTree = "<group>"; };
 		0D843ADA2B4B98C900F4EAD2 /* GPTHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTHTTPService.swift; sourceTree = "<group>"; };
 		0D843ADC2B4B992500F4EAD2 /* DataDecoderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDecoderable.swift; sourceTree = "<group>"; };
@@ -171,6 +179,7 @@
 		0D32600D2B5A085D000C352E /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				0D66D0D12B60AD2000F518CE /* PromptSettingRepository */,
 				0D32604D2B5D44BD000C352E /* ChattingRepository */,
 				0D3260202B5A18D0000C352E /* ChatRoomRepository */,
 				0D3260182B5A0E4B000C352E /* CoreDataRepository */,
@@ -306,6 +315,7 @@
 		0D32605A2B5E2628000C352E /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
+				0D66D0C82B60ACA500F518CE /* PromptSetting */,
 				0D32605C2B5E2636000C352E /* Chatting */,
 				0D32605B2B5E262F000C352E /* ChatRoom */,
 			);
@@ -316,7 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				0D3260242B5A24CA000C352E /* ChatRoom+CoreDataClass.swift */,
-				0D3260252B5A24CA000C352E /* ChatRoom+CoreDataProperties.swift */,
+				0D66D0DE2B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift */,
 			);
 			path = ChatRoom;
 			sourceTree = "<group>";
@@ -328,6 +338,40 @@
 				0D3260272B5A24CA000C352E /* Chatting+CoreDataProperties.swift */,
 			);
 			path = Chatting;
+			sourceTree = "<group>";
+		};
+		0D66D0C82B60ACA500F518CE /* PromptSetting */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0E32B60C42300F518CE /* PromptSetting+CoreDataProperties.swift */,
+				0D66D0DC2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift */,
+			);
+			path = PromptSetting;
+			sourceTree = "<group>";
+		};
+		0D66D0D12B60AD2000F518CE /* PromptSettingRepository */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0D52B60AE0100F518CE /* Implements */,
+				0D66D0D22B60AD4000F518CE /* Protocols */,
+			);
+			path = PromptSettingRepository;
+			sourceTree = "<group>";
+		};
+		0D66D0D22B60AD4000F518CE /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0D32B60AD5500F518CE /* PromptSettingRepositable.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		0D66D0D52B60AE0100F518CE /* Implements */ = {
+			isa = PBXGroup;
+			children = (
+				0D66D0D62B60AE2000F518CE /* CoreDataPromptSettingRepository.swift */,
+			);
+			path = Implements;
 			sourceTree = "<group>";
 		};
 		0D843AD92B4B98B200F4EAD2 /* HTTPService */ = {
@@ -552,8 +596,8 @@
 		0DF997672B43AD8F0055C836 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				0D32605A2B5E2628000C352E /* CoreData */,
 				0DF997822B463C610055C836 /* Model.swift */,
+				0D32605A2B5E2628000C352E /* CoreData */,
 				0D32601D2B5A1637000C352E /* GPTChatRoomDTO */,
 				0DF997752B43FF820055C836 /* GPTCommentDTO */,
 				0DF9976A2B43B1220055C836 /* GPTMessage */,
@@ -855,9 +899,11 @@
 				0D843AE92B4BA6D300F4EAD2 /* JSONEncoder+DataEncoderable.swift in Sources */,
 				0D3260162B5A0A56000C352E /* ChatRoomRepositable.swift in Sources */,
 				0D3260432B5A4C83000C352E /* GPTChatRoomsVMProtocol.swift in Sources */,
+				0D66D0E12B60C2C100F518CE /* ChatRoom+CoreDataProperties.swift in Sources */,
 				0DF997B52B479C0A0055C836 /* HTTPError.swift in Sources */,
 				0D3260592B5E21A9000C352E /* UIAlertController+Extension.swift in Sources */,
 				0D3260062B57724B000C352E /* AppEnviroment.swift in Sources */,
+				0D66D0E52B60C42300F518CE /* PromptSetting+CoreDataProperties.swift in Sources */,
 				0DF997AF2B479BA80055C836 /* GPTError.swift in Sources */,
 				0D32601F2B5A1651000C352E /* GPTChatRoom.swift in Sources */,
 				0D32602B2B5A24CA000C352E /* Chatting+CoreDataProperties.swift in Sources */,
@@ -874,16 +920,18 @@
 				B4B3E2C12B42D1BB00818B3C /* GPTChattingViewController.swift in Sources */,
 				0D843B302B4FF08400F4EAD2 /* GPTChattingCell.swift in Sources */,
 				0DF997832B463C610055C836 /* Model.swift in Sources */,
+				0D66D0DF2B60C2C100F518CE /* PromptSetting+CoreDataClass.swift in Sources */,
 				0DF997A72B4680BB0055C836 /* Network.swift in Sources */,
 				0DF997722B43BC590055C836 /* ToolMessage.swift in Sources */,
 				0D3260012B576362000C352E /* ChatRoomError.swift in Sources */,
 				0D3260042B576BC9000C352E /* BezierPath+extension.swift in Sources */,
 				0D843B392B511F0A00F4EAD2 /* UIChatBubbleView.swift in Sources */,
-				0D3260292B5A24CA000C352E /* ChatRoom+CoreDataProperties.swift in Sources */,
 				0D843B342B50CFAD00F4EAD2 /* WaitingMessage.swift in Sources */,
 				0D32601C2B5A1523000C352E /* Repository.swift in Sources */,
 				0D843AD82B4B986D00F4EAD2 /* URLSession+HTTPPublishable.swift in Sources */,
+				0D66D0D42B60AD5500F518CE /* PromptSettingRepositable.swift in Sources */,
 				0DF9977C2B440B890055C836 /* GPTReplyDTO.swift in Sources */,
+				0D66D0D72B60AE2000F518CE /* CoreDataPromptSettingRepository.swift in Sources */,
 				B4B3E2BD2B42D1BB00818B3C /* AppDelegate.swift in Sources */,
 				0D32601A2B5A0E6C000C352E /* CoreDataRepository.swift in Sources */,
 				0DF9976D2B43B15F0055C836 /* GPTMessagable.swift in Sources */,

--- a/ChatBot/ChatBot/Design/Extension/UITextView+Extension.swift
+++ b/ChatBot/ChatBot/Design/Extension/UITextView+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  UITextView+Extension.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/25/24.
+//
+
+import Foundation
+import UIKit
+
+extension UITextView {
+    func addDoneButton(title: String, target: Any?, selctor: Selector) {
+        let flexible = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let doneButton = UIBarButtonItem(title: title, style: .done, target: target, action: selctor)
+        let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: .max, height: .max))
+        toolBar.setItems([flexible, doneButton], animated: false)
+        toolBar.sizeToFit()
+        inputAccessoryView = toolBar
+    }
+}

--- a/ChatBot/ChatBot/Model/CoreData/ChatRoom/ChatRoom+CoreDataProperties.swift
+++ b/ChatBot/ChatBot/Model/CoreData/ChatRoom/ChatRoom+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  ChatRoom+CoreDataProperties.swift
 //  ChatBot
 //
-//  Created by 김준성 on 1/21/24.
+//  Created by 김준성 on 1/24/24.
 //
 //
 
@@ -20,6 +20,7 @@ extension ChatRoom {
     @NSManaged public var recentChatDate: Date?
     @NSManaged public var title: String?
     @NSManaged public var chattings: NSSet?
+    @NSManaged public var promptSetting: PromptSetting?
 
 }
 

--- a/ChatBot/ChatBot/Model/CoreData/PromptSetting/PromptSetting+CoreDataClass.swift
+++ b/ChatBot/ChatBot/Model/CoreData/PromptSetting/PromptSetting+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  PromptSetting+CoreDataClass.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(PromptSetting)
+public class PromptSetting: NSManagedObject {
+
+}

--- a/ChatBot/ChatBot/Model/CoreData/PromptSetting/PromptSetting+CoreDataProperties.swift
+++ b/ChatBot/ChatBot/Model/CoreData/PromptSetting/PromptSetting+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  PromptSetting+CoreDataProperties.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension PromptSetting {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<PromptSetting> {
+        return NSFetchRequest<PromptSetting>(entityName: "PromptSetting")
+    }
+
+    @NSManaged public var content: String?
+    @NSManaged public var role: String?
+    @NSManaged public var id: UUID?
+    @NSManaged public var chatRoom: ChatRoom?
+
+}
+
+extension PromptSetting : Identifiable {
+
+}

--- a/ChatBot/ChatBot/Model/GPTMessage/Implements/SystemMessage.swift
+++ b/ChatBot/ChatBot/Model/GPTMessage/Implements/SystemMessage.swift
@@ -11,6 +11,12 @@ extension Model {
         let content: String?
         let name: String?
         
+        init(role: GPTMessageRole, content: String? , name: String?) {
+            self.role = role
+            self.content = content
+            self.name = name
+        }
+        
         init(requestMessage: GPTMessage) {
             self.role = .system
             self.content = requestMessage.content

--- a/ChatBot/ChatBot/Model/GPTMessage/Implements/SystemMessage.swift
+++ b/ChatBot/ChatBot/Model/GPTMessage/Implements/SystemMessage.swift
@@ -11,8 +11,8 @@ extension Model {
         let content: String?
         let name: String?
         
-        init(role: GPTMessageRole, content: String? , name: String?) {
-            self.role = role
+        init(content: String? , name: String?) {
+            self.role = .system
             self.content = content
             self.name = name
         }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewController/GPTChatRoomsViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewController/GPTChatRoomsViewController.swift
@@ -87,13 +87,7 @@ final class GPTChatRoomsViewController: UIViewController {
         case .success(let chatRooms):
             applySnapshot(sectionRows: chatRooms.map { Row.forMain(title: $0.title, localeDateString: $0.recentChatDate.toLocaleString(.koKR)) })
         case .failure(let error):
-            UIAlertController.presentErrorPublisher(on: self, with: error)
-                .receive(on: DispatchQueue.main)
-                .sink { _ in
-                    print(self.cancellables.count)
-                }
-                .store(in: &cancellables)
-
+            present(UIAlertController(error: error), animated: true)
         }
     }
 }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewController/GPTChatRoomsViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewController/GPTChatRoomsViewController.swift
@@ -79,7 +79,10 @@ final class GPTChatRoomsViewController: UIViewController {
             .store(in: &cancellables)
         
         viewModel.error
-            .flatMap { UIAlertController.presentErrorPublisher(on: self, with: $0) }
+            .flatMap { [weak self] error in
+                guard let self = self else { return Empty<Void, Never>().eraseToAnyPublisher() }
+                return UIAlertController.presentErrorPublisher(on: self, with: error)
+            }
             .sink { _ in }
             .store(in: &cancellables)
     }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
@@ -78,8 +78,12 @@ extension GPTChatRoomsViewModel: GPTChatRoomsInputProtocol {
             outputSubject.send(output)
             return
         }
-        let viewModel = GPTChattingViewModel(chatRoomDTO: chatRoom, httpRequest: Network.GPTRequest.chatBot(apiKey: apiKey))
-        outputSubject.send(Output.moveToChatRoom(.success(viewModel)))
+        
+        let chatRoomViewModel = GPTChattingViewModel(chatRoomDTO: chatRoom, httpRequest: Network.GPTRequest.chatBot(apiKey: apiKey))
+        let promptSettingViewModel = GPTPromptSettingViewModel(chatRoom: chatRoom)
+        
+        outputSubject.send(Output.moveToChatRoom(.success(chatRoomViewModel)))
+        outputSubject.send(Output.moveToPromptSetting(.success(promptSettingViewModel)))
     }
 }
 

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-final class GPTChatRoomsViewModel: GPTChatRoomsOutputProtocol {
+final class GPTChatRoomsViewModel: GPTChatRoomsOutput {
     private let chatRoomRepository: ChatRoomRepositable
     
     private let updateChatRoomsSubject = PassthroughSubject<[Model.GPTChatRoomDTO], Never>()
@@ -29,7 +29,7 @@ final class GPTChatRoomsViewModel: GPTChatRoomsOutputProtocol {
     }
 }
 
-extension GPTChatRoomsViewModel: GPTChatRoomsInputProtocol {
+extension GPTChatRoomsViewModel: GPTChatRoomsInput {
     func onViewDidLoad() { }
     
     func onViewWillAppear() {

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Implements/GPTChatRoomsViewModel.swift
@@ -87,7 +87,7 @@ extension GPTChatRoomsViewModel {
     private func handleRooms(_ handler: () throws -> Void) -> Output {
         do {
             try handler()
-            return Output.updateChatRooms(.success(chatRoomList))
+            return Output.updateChatRooms(.success(chatRoomList.reversed()))
         } catch {
             return Output.updateChatRooms(.failure(error))
         }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
@@ -27,4 +27,5 @@ protocol GPTChatRoomsOutputProtocol {
 enum GPTChatRoomsOutput {
     case updateChatRooms(Result<[Model.GPTChatRoomDTO], Error>)
     case moveToChatRoom(Result<any GPTChattingVMProtocol, Error>)
+    case moveToPromptSetting(Result<any GPTPromptSettingVMProtocol, Error>)
 }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
@@ -8,9 +8,9 @@
 import Combine
 import Foundation
 
-typealias GPTChatRoomsVMProtocol = GPTChatRoomsInputProtocol & GPTChatRoomsOutputProtocol
+typealias GPTChatRoomsVMProtocol = GPTChatRoomsInput & GPTChatRoomsOutput
 
-protocol GPTChatRoomsInputProtocol {
+protocol GPTChatRoomsInput {
     func onViewDidLoad()
     func onViewWillAppear()
     func onViewDidDisappear()
@@ -20,7 +20,7 @@ protocol GPTChatRoomsInputProtocol {
     func selectRoom(for indexPath: IndexPath)
 }
 
-protocol GPTChatRoomsOutputProtocol {
+protocol GPTChatRoomsOutput {
     var updateChatRooms: AnyPublisher<[Model.GPTChatRoomDTO], Never> { get }
     var moveToChatting: AnyPublisher<any GPTChattingVMProtocol, Never> { get }
     var moveToPromptSetting: AnyPublisher<any GPTPromptSettingVMProtocol, Never> { get }

--- a/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatRooms/ViewModel/Protocols/GPTChatRoomsVMProtocol.swift
@@ -21,11 +21,8 @@ protocol GPTChatRoomsInputProtocol {
 }
 
 protocol GPTChatRoomsOutputProtocol {
-    var output: AnyPublisher<GPTChatRoomsOutput, Never> { get }
-}
-
-enum GPTChatRoomsOutput {
-    case updateChatRooms(Result<[Model.GPTChatRoomDTO], Error>)
-    case moveToChatRoom(Result<any GPTChattingVMProtocol, Error>)
-    case moveToPromptSetting(Result<any GPTPromptSettingVMProtocol, Error>)
+    var updateChatRooms: AnyPublisher<[Model.GPTChatRoomDTO], Never> { get }
+    var moveToChatting: AnyPublisher<any GPTChattingVMProtocol, Never> { get }
+    var moveToPromptSetting: AnyPublisher<any GPTPromptSettingVMProtocol, Never> { get }
+    var error: AnyPublisher<Error, Never> { get }
 }

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
@@ -61,12 +61,6 @@ final class GPTChattingViewController: UIViewController {
     }()
     
     private let viewModel: any GPTChattingVMProtocol
-    private let cellResistration = UICollectionView.CellRegistration<GPTChattingCell, Row> { cell, indexPath, itemIdentifier in
-        switch itemIdentifier {
-        case .forMain(let message):
-            cell.configureCell(to: message)
-        }
-    }
     
     private var chattingDataSource: UICollectionViewDiffableDataSource<Section, Row>!
     private var cancellables = Set<AnyCancellable>()
@@ -74,6 +68,12 @@ final class GPTChattingViewController: UIViewController {
     init(viewModel: any GPTChattingVMProtocol) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+    }
+    
+    deinit {
+        for cancellable in cancellables {
+            cancellable.cancel()
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -167,10 +167,17 @@ extension GPTChattingViewController {
 // MARK: - configure Diffable Data Source
 extension GPTChattingViewController {
     private func configureDataSource() {
+        let cellResistration = UICollectionView.CellRegistration<GPTChattingCell, Row> { cell, indexPath, itemIdentifier in
+            switch itemIdentifier {
+            case .forMain(let message):
+                cell.configureCell(to: message)
+            }
+        }
+        
         chattingDataSource = UICollectionViewDiffableDataSource<Section, Row>(
             collectionView: chatCollectionView,
             cellProvider: { collectionView, indexPath, itemIdentifier in
-                collectionView.dequeueConfiguredReusableCell(using: self.cellResistration, for: indexPath, item: itemIdentifier)
+                collectionView.dequeueConfiguredReusableCell(using: cellResistration, for: indexPath, item: itemIdentifier)
             }
         )
     }

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
@@ -109,7 +109,10 @@ final class GPTChattingViewController: UIViewController {
             .store(in: &cancellables)
         
         viewModel.error
-            .flatMap { UIAlertController.presentErrorPublisher(on: self, with: $0) }
+            .flatMap { [weak self] error in
+                guard let self = self else { return Empty<Void, Never>().eraseToAnyPublisher() }
+                return UIAlertController.presentErrorPublisher(on: self, with: error)
+            }
             .sink { _ in }
             .store(in: &cancellables)
     }

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewController/GPTChattingViewController.swift
@@ -21,6 +21,7 @@ final class GPTChattingViewController: UIViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: configureCollectionViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(GPTChattingCell.self, forCellWithReuseIdentifier: "\(type(of: GPTChattingCell.self))")
+        collectionView.keyboardDismissMode = .onDrag
         return collectionView
     }()
     

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
@@ -53,7 +53,7 @@ final class GPTChattingViewModel {
             return reply
         }
         
-        var cancellable: AnyCancellable! = nil
+        var cancellable: AnyCancellable = AnyCancellable{ }
         cancellable = networkPublisher
             .sink { [weak self] completion in
                 guard let self else { return }
@@ -69,7 +69,7 @@ final class GPTChattingViewModel {
                 guard let self else { return }
                 messages[indexToUpdate] = message
             }
-        cancellable?.store(in: &cancellables)
+        cancellable.store(in: &cancellables)
     }
 }
 

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
@@ -73,12 +73,12 @@ final class GPTChattingViewModel {
     }
 }
 
-extension GPTChattingViewModel: GPTChattingOutputProtocol {
+extension GPTChattingViewModel: GPTChattingOutput {
     var updateChattings: AnyPublisher<(messages: [Model.GPTMessage], indexToUpdate: Int), Never> { updateChattingsSubject.eraseToAnyPublisher() }
     var error: AnyPublisher<Error, Never> { errorSubject.eraseToAnyPublisher() }
 }
 
-extension GPTChattingViewModel: GPTChattingsInputProtocol {
+extension GPTChattingViewModel: GPTChattingsInput {
     func onViewDidLoad() { }
     
     func onViewWillAppear() {

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Implements/GPTChattingViewModel.swift
@@ -43,7 +43,6 @@ final class GPTChattingViewModel: GPTChattingOutputProtocol {
         if let systemMessage = systemMessage {
             sendMessage = [systemMessage] + sendMessage
         }
-        print(sendMessage)
         
         let networkPublisher = httpService.request(
             request: httpRequest,

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Protocols/GPTChattingVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Protocols/GPTChattingVMProtocol.swift
@@ -17,10 +17,6 @@ protocol GPTChattingsInputProtocol {
 }
 
 protocol GPTChattingOutputProtocol {
-    var output: AnyPublisher<GPTChattingOutput, Never> { get }
-}
-
-enum GPTChattingOutput {
-    case networkChatting(Result<(messages: [Model.GPTMessage], indexToUpdate: Int), Error>)
-    case fetchChattings(Result<(messages: [Model.GPTMessage], indexToUpdate: Int), Error>)
+    var updateChattings: AnyPublisher<(messages: [Model.GPTMessage], indexToUpdate: Int), Never> { get }
+    var error: AnyPublisher<Error, Never> { get }
 }

--- a/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Protocols/GPTChattingVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTChatting/ViewModel/Protocols/GPTChattingVMProtocol.swift
@@ -7,16 +7,16 @@
 
 import Combine
 
-typealias GPTChattingVMProtocol = GPTChattingsInputProtocol & GPTChattingOutputProtocol
+typealias GPTChattingVMProtocol = GPTChattingsInput & GPTChattingOutput
 
-protocol GPTChattingsInputProtocol {
+protocol GPTChattingsInput {
     func onViewDidLoad()
     func onViewWillAppear()
     func onViewWillDisappear()
     func sendChat(_ content: String?)
 }
 
-protocol GPTChattingOutputProtocol {
+protocol GPTChattingOutput {
     var updateChattings: AnyPublisher<(messages: [Model.GPTMessage], indexToUpdate: Int), Never> { get }
     var error: AnyPublisher<Error, Never> { get }
 }

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
@@ -47,26 +47,17 @@ final class GPTPromptSettingViewController: UIViewController {
     }
     
     private func bind(to viewModel: GPTPromptSettingVMProtocol) {
-        viewModel.output
+        viewModel.fetchPromptSetting
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] output in
-                switch output {
-                case .fetch(let result):
-                    self?.handleFetchString(result)
-                case .store:
-                    break
-                }
+            .sink { [weak self] content in
+                self?.textView.text = content
             }
             .store(in: &cancellables)
-    }
-    
-    private func handleFetchString(_ result: Result<String?, Error>) {
-        switch result {
-        case .success(let content):
-            textView.text = content
-        case .failure(let error):
-            present(UIAlertController(error: error), animated: true)
-        }
+        
+        viewModel.error
+            .flatMap { UIAlertController.presentErrorPublisher(on: self, with: $0) }
+            .sink { _ in }
+            .store(in: &cancellables)
     }
 }
 
@@ -75,7 +66,7 @@ extension GPTPromptSettingViewController {
     private func configureUI() {
         NSLayoutConstraint.activate([
             textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
             textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
             textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8)
         ])

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
@@ -19,6 +19,8 @@ final class GPTPromptSettingViewController: UIViewController {
         textView.layer.borderWidth = 3
         textView.textColor = .black
         textView.layer.borderColor = UIColor.lightGray.cgColor
+        textView.delegate = self
+        textView.addDoneButton(title: "저장", target: self, selctor: #selector(tapDoneButton))
         view.addSubview(textView)
         return textView
     }()
@@ -42,11 +44,6 @@ final class GPTPromptSettingViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewModel.onViewWillAppear()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        viewModel.storeUpdatePromptSetting(content: textView.text)
     }
     
     private func bind(to viewModel: GPTPromptSettingVMProtocol) {
@@ -82,5 +79,16 @@ extension GPTPromptSettingViewController {
             textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
             textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8)
         ])
+    }
+    
+    @objc
+    private func tapDoneButton() {
+        view.endEditing(true)
+    }
+}
+
+extension GPTPromptSettingViewController: UITextViewDelegate {
+    func textViewDidEndEditing(_ textView: UITextView) {
+        viewModel.storeUpdatePromptSetting(content: textView.text)
     }
 }

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
@@ -55,7 +55,10 @@ final class GPTPromptSettingViewController: UIViewController {
             .store(in: &cancellables)
         
         viewModel.error
-            .flatMap { UIAlertController.presentErrorPublisher(on: self, with: $0) }
+            .flatMap { [weak self] error in
+                guard let self = self else { return Empty<Void, Never>().eraseToAnyPublisher() }
+                return UIAlertController.presentErrorPublisher(on: self, with: error)
+            }
             .sink { _ in }
             .store(in: &cancellables)
     }

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewController/GPTPromptSettingViewController.swift
@@ -1,0 +1,86 @@
+//
+//  GPTPromptSettingViewController.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+
+import Combine
+import UIKit
+
+final class GPTPromptSettingViewController: UIViewController {
+    private let viewModel: GPTPromptSettingVMProtocol
+    private var cancellables = Set<AnyCancellable>()
+    
+    private lazy var textView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.backgroundColor = .white
+        textView.layer.borderWidth = 3
+        textView.textColor = .black
+        textView.layer.borderColor = UIColor.lightGray.cgColor
+        view.addSubview(textView)
+        return textView
+    }()
+    
+    init(viewModel: GPTPromptSettingVMProtocol) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bind(to: viewModel)
+        configureUI()
+        viewModel.onViewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.onViewWillAppear()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewModel.storeUpdatePromptSetting(content: textView.text)
+    }
+    
+    private func bind(to viewModel: GPTPromptSettingVMProtocol) {
+        viewModel.output
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] output in
+                switch output {
+                case .fetch(let result):
+                    self?.handleFetchString(result)
+                case .store:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleFetchString(_ result: Result<String?, Error>) {
+        switch result {
+        case .success(let content):
+            textView.text = content
+        case .failure(let error):
+            present(UIAlertController(error: error), animated: true)
+        }
+    }
+}
+
+// MARK: - configure UI
+extension GPTPromptSettingViewController {
+    private func configureUI() {
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8),
+            textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8)
+        ])
+    }
+}

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Implements/GPTPromptSettingViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Implements/GPTPromptSettingViewModel.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-final class GPTPromptSettingViewModel: GPTPromptSettingOutputProtocol {
+final class GPTPromptSettingViewModel: GPTPromptSettingOutput {
     private let chatRoom: Model.GPTChatRoomDTO
     private let fetchPromptSettingSubject = PassthroughSubject<String?, Never>()
     private let errorSubject = PassthroughSubject<Error, Never>()
@@ -35,7 +35,7 @@ final class GPTPromptSettingViewModel: GPTPromptSettingOutputProtocol {
     }
 }
 
-extension GPTPromptSettingViewModel: GPTPromptSettingInputProtocol {
+extension GPTPromptSettingViewModel: GPTPromptSettingInput {
     func onViewDidLoad() { }
     
     func onViewWillAppear() {

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Implements/GPTPromptSettingViewModel.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Implements/GPTPromptSettingViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  GPTPromptSettingViewModel.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+
+import Combine
+import Foundation
+
+final class GPTPromptSettingViewModel: GPTPromptSettingOutputProtocol {
+    typealias Output = GPTPromptSettingOutput
+    
+    private let chatRoom: Model.GPTChatRoomDTO
+    private var systemMessage: Model.SystemMessage?
+    
+    private let promptSettingRepository: PromptSettingRepositable
+    private let outputSubject = PassthroughSubject<GPTPromptSettingOutput, Never>()
+    
+    var output: AnyPublisher<GPTPromptSettingOutput, Never> { outputSubject.eraseToAnyPublisher() }
+    
+    init(chatRoom: Model.GPTChatRoomDTO, promptSettingRepository: PromptSettingRepositable = Repository.CoreDataPromptSettingRepository()) {
+        self.chatRoom = chatRoom
+        self.promptSettingRepository = promptSettingRepository
+    }
+    
+    private func fetchPromptSetting() throws {
+        systemMessage = try promptSettingRepository.fetchPromptSetting(for: chatRoom)
+        outputSubject.send(.fetch(.success(systemMessage?.content)))
+    }
+}
+
+extension GPTPromptSettingViewModel: GPTPromptSettingInputProtocol {
+    func onViewDidLoad() { }
+    
+    func onViewWillAppear() {
+        do {
+            try fetchPromptSetting()
+        } catch {
+            outputSubject.send(.fetch(.failure(error)))
+        }
+    }
+    
+    func storeUpdatePromptSetting(content: String?) {
+        do {
+            guard let content = content, !content.isEmpty else {
+                try promptSettingRepository.deletePromptSetting(for: chatRoom)
+                return
+            }
+            
+            let newSystemMessage = Model.SystemMessage(content: content, name: nil)
+            try promptSettingRepository.storePromptSetting(newSystemMessage, for: chatRoom)
+        } catch {
+            print(error)
+        }
+    }
+}

--- a/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Protocols/GPTPromptSettingVMProtocol.swift
+++ b/ChatBot/ChatBot/Presentation/GPTPromptSetting/ViewModel/Protocols/GPTPromptSettingVMProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  GPTPromptSettingVMProtocol.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/26/24.
+//
+
+import Combine
+import Foundation
+
+typealias GPTPromptSettingVMProtocol = GPTPromptSettingInput & GPTPromptSettingOutput
+
+protocol GPTPromptSettingInput {
+    func onViewDidLoad()
+    func onViewWillAppear()
+    func storeUpdatePromptSetting(content: String?)
+}
+
+protocol GPTPromptSettingOutput {
+    var fetchPromptSetting: AnyPublisher<String?, Never> { get }
+    var error: AnyPublisher<Error, Never> { get }
+}

--- a/ChatBot/ChatBot/Repository/PromptSettingRepository/Implements/CoreDataPromptSettingRepository.swift
+++ b/ChatBot/ChatBot/Repository/PromptSettingRepository/Implements/CoreDataPromptSettingRepository.swift
@@ -1,0 +1,82 @@
+//
+//  CoreDataPromptSettingRepository.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+
+import CoreData
+import Foundation
+
+extension Repository {
+    final class CoreDataPromptSettingRepository {
+        let coreDataRepository: Repository.CoreDataRepository
+        
+        init(coreDataRepository: Repository.CoreDataRepository = AppEnviroment.defaultCDRepository) {
+            self.coreDataRepository = coreDataRepository
+        }
+        
+        private func fetchChatRoom(_ chatRoom: Model.GPTChatRoomDTO) throws -> ChatRoom {
+            let request = ChatRoom.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", chatRoom.id.uuidString)
+            
+            guard let chatRoomCD = try coreDataRepository.context.fetch(request).first else {
+                throw GPTError.RepositoryError.dataNotFound
+            }
+            
+            return chatRoomCD
+        }
+    }
+}
+
+extension Repository.CoreDataPromptSettingRepository: PromptSettingRepositable {
+    func fetchPromptSetting(for chatRoom: Model.GPTChatRoomDTO) throws -> Model.SystemMessage? {
+        let chatRoomCD = try fetchChatRoom(chatRoom)
+        
+        guard let prompt = chatRoomCD.promptSetting else {
+            return nil
+        }
+        
+        return Model.SystemMessage(content: prompt.content, name: nil)
+    }
+    
+    func modifyPromptSetting(_ systemMessage: Model.SystemMessage, for chatRoom: Model.GPTChatRoomDTO) throws {
+        let chatRoomCD = try fetchChatRoom(chatRoom)
+        
+        guard let prompt = chatRoomCD.promptSetting else {
+            throw GPTError.RepositoryError.dataNotFound
+        }
+        
+        prompt.content = systemMessage.content
+        
+        try coreDataRepository.saveContext()
+    }
+    
+    func deletePromptSetting(for chatRoom: Model.GPTChatRoomDTO) throws {
+        let chatRoomCD = try fetchChatRoom(chatRoom)
+        
+        guard let promptSetting = chatRoomCD.promptSetting else {
+            throw GPTError.RepositoryError.dataNotFound
+        }
+        
+        coreDataRepository.context.delete(promptSetting)
+        
+        try coreDataRepository.saveContext()
+    }
+    
+    func storePromptSetting(_ systemMessage: Model.SystemMessage, for chatRoom: Model.GPTChatRoomDTO) throws {
+        let chatRoomCD = try fetchChatRoom(chatRoom)
+        
+        guard let promptSetting = NSManagedObject(entity: PromptSetting.entity(), insertInto: coreDataRepository.context) as? PromptSetting else {
+            throw GPTError.RepositoryError.contextNotFound
+        }
+        promptSetting.id = UUID()
+        promptSetting.role = systemMessage.role.rawValue
+        promptSetting.content = systemMessage.content
+        promptSetting.chatRoom = chatRoomCD
+        
+        chatRoomCD.promptSetting = promptSetting
+        
+        try coreDataRepository.saveContext()
+    }
+}

--- a/ChatBot/ChatBot/Repository/PromptSettingRepository/Implements/CoreDataPromptSettingRepository.swift
+++ b/ChatBot/ChatBot/Repository/PromptSettingRepository/Implements/CoreDataPromptSettingRepository.swift
@@ -56,7 +56,7 @@ extension Repository.CoreDataPromptSettingRepository: PromptSettingRepositable {
         let chatRoomCD = try fetchChatRoom(chatRoom)
         
         guard let promptSetting = chatRoomCD.promptSetting else {
-            throw GPTError.RepositoryError.dataNotFound
+            return
         }
         
         coreDataRepository.context.delete(promptSetting)

--- a/ChatBot/ChatBot/Repository/PromptSettingRepository/Protocols/PromptSettingRepositable.swift
+++ b/ChatBot/ChatBot/Repository/PromptSettingRepository/Protocols/PromptSettingRepositable.swift
@@ -1,0 +1,15 @@
+//
+//  PromptSettingRepositable.swift
+//  ChatBot
+//
+//  Created by 김준성 on 1/24/24.
+//
+
+import Foundation
+
+protocol PromptSettingRepositable {
+    func fetchPromptSetting(for chatRoom: Model.GPTChatRoomDTO) throws -> Model.SystemMessage?
+    func modifyPromptSetting(_ systemMessage: Model.SystemMessage, for chatRoom: Model.GPTChatRoomDTO) throws
+    func deletePromptSetting(for chatRoom: Model.GPTChatRoomDTO) throws
+    func storePromptSetting(_ systemMessage: Model.SystemMessage, for chatRoom: Model.GPTChatRoomDTO) throws
+}

--- a/ChatBot/ChatBot/Resource/ChatBotCoreData.xcdatamodeld/ChatBotCoreData.xcdatamodel/contents
+++ b/ChatBot/ChatBot/Resource/ChatBotCoreData.xcdatamodeld/ChatBotCoreData.xcdatamodel/contents
@@ -5,6 +5,7 @@
         <attribute name="recentChatDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <relationship name="chattings" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Chatting" inverseName="chatRoom" inverseEntity="Chatting"/>
+        <relationship name="promptSetting" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="PromptSetting" inverseName="chatRoom" inverseEntity="PromptSetting"/>
     </entity>
     <entity name="Chatting" representedClassName="Chatting" syncable="YES">
         <attribute name="content" optional="YES" attributeType="String"/>
@@ -12,5 +13,11 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="role" optional="YES" attributeType="String"/>
         <relationship name="chatRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatRoom" inverseName="chattings" inverseEntity="ChatRoom"/>
+    </entity>
+    <entity name="PromptSetting" representedClassName="PromptSetting" syncable="YES">
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="role" optional="YES" attributeType="String"/>
+        <relationship name="chatRoom" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ChatRoom" inverseName="promptSetting" inverseEntity="ChatRoom"/>
     </entity>
 </model>

--- a/ChatBot/ChatBotTests/Stubs/StubHTTPPublisher.swift
+++ b/ChatBot/ChatBotTests/Stubs/StubHTTPPublisher.swift
@@ -1,0 +1,57 @@
+//
+//  StubHTTPPublisher.swift
+//  ChatBotTests
+//
+//  Created by 김준성 on 1/26/24.
+//
+
+import Combine
+import Foundation
+
+@testable import ChatBot
+
+final class StubGPTHTTPPublisher: HTTPPublishable {
+    var isNotError: Bool
+    
+    let response = """
+{
+  "id": "chatcmpl-8l7V2moUwlwkh1BhV7cDjJl2j8RUx",
+  "object": "chat.completion",
+  "created": 1706240936,
+  "model": "gpt-3.5-turbo-1106",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "안녕! 문제가 있으면 언제든 물어봐줘~"
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 355,
+    "completion_tokens": 24,
+    "total_tokens": 379
+  },
+  "system_fingerprint": "fp_b57c83dd65"
+}
+""".data(using: .utf8)!
+    
+    init(isNotError: Bool) {
+        self.isNotError = isNotError
+    }
+    
+    func responsePublisher(urlRequest: URLRequest) -> AnyPublisher<Data, ChatBot.GPTError.HTTPError> {
+        Future { [unowned self] promise in
+            if isNotError {
+                promise(.success(response))
+            } else {
+                promise(.failure(GPTError.HTTPError.invalidURL))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+    

--- a/ChatBot/ChatBotTests/Tests/GPTChattingVMTests.swift
+++ b/ChatBot/ChatBotTests/Tests/GPTChattingVMTests.swift
@@ -1,0 +1,74 @@
+//
+//  GPTChattingVMTests.swift
+//  ChatBotTests
+//
+//  Created by 김준성 on 1/26/24.
+//
+
+import Combine
+import Foundation
+import XCTest
+
+@testable import ChatBot
+
+final class GPTChattingVMTests: XCTestCase {
+    let chatRoom = Model.GPTChatRoomDTO(title: "test", recentChatDate: Date())
+    var publisher: StubGPTHTTPPublisher!
+    var viewModel: GPTChattingVMProtocol!
+    var cancellables: Set<AnyCancellable>!
+    
+    override func setUpWithError() throws {
+        publisher = StubGPTHTTPPublisher(isNotError: true)
+        let service = Network.GPTHTTPService(publisher: publisher, encoder: JSONEncoder(), decoder: JSONDecoder())
+        viewModel = GPTChattingViewModel(chatRoomDTO: chatRoom, httpService: service, httpRequest: Network.GPTRequest.chatBot(apiKey: "test"))
+        cancellables = Set()
+    }
+    
+    override func tearDownWithError() throws {
+        publisher = nil
+        viewModel = nil
+        cancellables = nil
+    }
+    
+    func test_네트워크_통신을_통해_채팅을_기존_배열에_더해서_배열의_개수를_하나_늘린다() {
+        // given
+        publisher.isNotError = true
+        
+        // expect
+        let messagesCount = 2
+        
+        viewModel.updateChattings
+            .sink { (messages: [Model.GPTMessage], indexToUpdate: Int) in
+                // then(Success)
+                XCTAssertEqual(messagesCount, messages.count)
+            }
+            .store(in: &cancellables)
+        
+        viewModel.error
+            .sink { error in
+                // then(Fail)
+                XCTFail(error.localizedDescription)
+            }
+            .store(in: &cancellables)
+        
+        // when
+        viewModel.sendChat("123")
+    }
+    
+    func test_네트워크_통신이_에러가_났을_때_에러를_sink_받는다() {
+        publisher.isNotError = false
+        
+        // expect
+        let expectedError = GPTError.HTTPError.invalidURL
+        
+        viewModel.error
+            .sink { error in
+                // then(Success)
+                XCTAssertEqual(expectedError.localizedDescription, error.localizedDescription)
+            }
+            .store(in: &cancellables)
+        
+        // when
+        viewModel.sendChat("123")
+    }
+}


### PR DESCRIPTION
안녕하세요👋 린생(@jungseungyeo)! STEP5을 다 해서 PR을 올립니다. 확인해주시면 감사하겠습니다!

### To-do List
- Prompt Setting CoreData Repository 구현
- SystemMessage CRUD
- TabbController 생성

# 시현 영상
![Simulator Screen Recording - iPhone 15 Pro - 2024-01-25 at 17 30 46](https://github.com/tasty-code/ios-chat-bot/assets/107932188/e827a650-1a37-4842-97f4-fee113fac6c9)

# STEP5 진행 중 경험 사항

## MVVM 수정
### {기능명}OutputProtocol의 수정
STEP5를 진행하면서 2개의 ViewController를 결합하여 Tabbar를 만들어야 했습니다.
그러나 기존의 방식으로 진행하게 되면 Output이 열거형이라 각각의 케이스를 퍼블리셔로 분리해내는데 어려움이 있었습니다.
또한 밑에 나올 AlertController를 퍼블리셔로 사용하는데도 어려움이 있었습니다.
따라서 열거형으로 두지 않고 독립된 프로퍼티로 둬서 해결했습니다.
#### 수정 전
- GPTChatRoomsVMProtocol.swift
```swift
typealias GPTChatRoomsVMProtocol = GPTChatRoomsInputProtocol & GPTChatRoomsOutputProtocol

protocol GPTChatRoomsInputProtocol {
    func onViewDidLoad()
    func onViewWillAppear()
    func onViewDidDisappear()
    func createRoom(_ roomName: String?)
    func modifyRoom(_ roomName: String?, for indexPath: IndexPath)
    func deleteRoom(for indexPath: IndexPath)
    func selectRoom(for indexPath: IndexPath)
}

protocol GPTChatRoomsOutputProtocol {
    var output: AnyPublisher<GPTChatRoomsOutput, Never> { get }
}

enum GPTChatRoomsOutput {
    case updateChatRooms(Result<[Model.GPTChatRoomDTO], Error>)
    case moveToChatRoom(Result<any GPTChattingVMProtocol, Error>)
    case moveToPromptSetting(Result<any GPTPromptSettingVMProtocol, Error>)
}
```
#### 수정 후
- GPTChatRoomsVMProtocol.swift
```swift
typealias GPTChatRoomsVMProtocol = GPTChatRoomsInput & GPTChatRoomsOutput

protocol GPTChatRoomsInput {
    func onViewDidLoad()
    func onViewWillAppear()
    func onViewDidDisappear()
    func createRoom(_ roomName: String?)
    func modifyRoom(_ roomName: String?, for indexPath: IndexPath)
    func deleteRoom(for indexPath: IndexPath)
    func selectRoom(for indexPath: IndexPath)
}

protocol GPTChatRoomsOutput {
    var updateChatRooms: AnyPublisher<[Model.GPTChatRoomDTO], Never> { get }
    var moveToChatting: AnyPublisher<any GPTChattingVMProtocol, Never> { get }
    var moveToPromptSetting: AnyPublisher<any GPTPromptSettingVMProtocol, Never> { get }
    var error: AnyPublisher<Error, Never> { get }
}
```
### 프로토콜 수정에 따른 바인딩 수정
`GPTChatRoomsOutput`의 `moveToChatting`, `moveToPromptSetting`의 ViewModel을 이용하여 탭바 컨트롤러를 만들어야 했습니다.
물론 채팅방 정보를 publish해서, 그 정보를 바탕으로 ViewController에서 ViewModel을 만드는 방법도 있었지만, 그것은 옳지 않다고 생각했습니다.
View(View Controller)의 역할이 아닌 것 같기도 했고, ViewController에서 구체화된 ViewModel 타입을 만들면 VMProtocol을 별개로 만든 이유가 사라지기 때문입니다.
따라서 두 퍼블리셔(`moveToChatting`, `moveToPromptSetting`)를 Zip으로 묶어서, 이를 바탕으로 탭바를 만들도록 했습니다.
- GPTChatRoomsViewController.swift
```swift
final class GPTChatRoomsViewController: UIViewController {
// ...
    private func bind(to viewModel: any GPTChatRoomsVMProtocol) {
        Publishers.Zip(viewModel.moveToChatting, viewModel.moveToPromptSetting)
            .receive(on: DispatchQueue.main)
            .sink { [weak self] (chattingViewModel, promptSettingViewModel) in
                let chattingVC = GPTChattingViewController(viewModel: chattingViewModel)
                let promptSettingVC = GPTPromptSettingViewController(viewModel: promptSettingViewModel)
                guard let tabbarVC = self?.configureTabbarController(chattingVC, promptSettingVC) else { return }
                
                self?.navigationController?.pushViewController(tabbarVC, animated: true)
            }
            .store(in: &cancellables)
        
        viewModel.updateChatRooms
            .receive(on: DispatchQueue.main)
            .sink(receiveValue: { [weak self] chatRooms in
                self?.handleUpdateChatRooms(chatRooms)
            })
            .store(in: &cancellables)
        // ...
    }
// ...
}
```
## AlertController 개선
### AlertController Publisher 사용 방식 수정
위의 [경험사항](#프로토콜-수정에-따른-바인딩-수정)과 연결되는 이야기인데,
열거형으로 두었을 때, 각 케이스마다 에러 타입을 뽑아내는게 굉장히 비효율적이라는 느낌을 받았습니다.
그렇게 때문에 불가피하게 [이전의 코드](https://github.com/tasty-code/ios-chat-bot/pull/24#issuecomment-1905361274) 방식을 사용했습니다. 에러 또한 Output의 프로퍼티로 두어 이 문제를 해결했습니다.
```swift
final class GPTChatRoomsViewController: UIViewController {
// ...
    private func bind(to viewModel: any GPTChatRoomsVMProtocol) {
        // ...
        viewModel.error
            .flatMap { UIAlertController.presentErrorPublisher(on: self, with: $0) }
            .sink { _ in }
            .store(in: &cancellables)
    }
}
```

## 기타
### 메모리 누수 제거
각 `ViewController`의 `deinit`이 제대로 호출되는지 확인하고자, 테스트를 진행해봤는데,
`GPTChattingViewController`의 `deinit`이 호출이 되지 않았습니다.
`UICollectionViewDiffableDataSource`를 생성할 때, 셀 생성 방식을 등록하는 과정에서 강한 참조를 하고 있었기에 발생한 문제였습니다.
따라서 `cellResistration`를 함수 코드 블럭 내부에 배치해서 메모리 누수를 해결했습니다.
#### 수정 전
- GPTChattingViewController.swift
```swift
final class GPTChattingViewController: UIViewController {
// ...
    private let cellResistration = UICollectionView.CellRegistration<GPTChattingCell, Row> { cell, indexPath, itemIdentifier in
        switch itemIdentifier {
        case .forMain(let message):
            cell.configureCell(to: message)
        }
    }
    // ...
    private func configureDataSource() {
        chattingDataSource = UICollectionViewDiffableDataSource<Section, Row>(
            collectionView: chatCollectionView,
            cellProvider: { collectionView, indexPath, itemIdentifier in
                collectionView.dequeueConfiguredReusableCell(using: self.cellResistration, for: indexPath, item: itemIdentifier)
            }
        )
    }
// ...
}
```
#### 수정 후
- GPTChattingViewController.swift
```swift
final class GPTChattingViewController: UIViewController {
// ...
    private func configureDataSource() {
        let cellResistration = UICollectionView.CellRegistration<GPTChattingCell, Row> { cell, indexPath, itemIdentifier in
            switch itemIdentifier {
            case .forMain(let message):
                cell.configureCell(to: message)
            }
        }
        
        chattingDataSource = UICollectionViewDiffableDataSource<Section, Row>(
            collectionView: chatCollectionView,
            cellProvider: { collectionView, indexPath, itemIdentifier in
                collectionView.dequeueConfiguredReusableCell(using: cellResistration, for: indexPath, item: itemIdentifier)
            }
        )
    }
// ...
}
```
## 궁금증?
### UI의 Publisher화?
이번에 AlertController를 publish하게끔 바꿔봤는데(사실 제대로 만든 것인지도 확신이 없습니다;), 사실 잘 와닿지 않았습니다.
오히려 Rx, Combine같은 이벤트 처리 프레임워크를 모르는 사람이 보았을 때, 더 혼란이 가중될 것 같기도 하고
UI요소의 변화(창 띄우기, 삭제하기 등)을 Publisher로 만드는게 사용하는 것보다 비용이 더 많이 든다고 생각하기 때문입니다.(사실 비용이 더 많이 드는 건 제 실력이 부족해서 그런 것일 수 도 있습니다.)
그럼에도 불구하고 UI를 Publisher로 만드는 이유가 있을까요?